### PR TITLE
feat: use get-github-auth-token for gh auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,18 @@
 
 ## CLI
 
-`prune-github-notifications` can be run on the CLI with an auth token for _notifications_ access specified as a `GH_TOKEN` environment variable:
+`prune-github-notifications` can be run on the CLI with an auth token for _notifications_ access:
 
 ```shell
-GH_TOKEN=$(gh auth token) npx prune-github-notifications
+npx prune-github-notifications
 ```
+
+[`get-github-auth-token`](https://github.com/JoshuaKGoldberg/get-github-auth-token) is used to retrieve a GitHub auth token from `process.env.GH_TOKEN` or executing `gh auth token`.
 
 ### CLI Options
 
-Only `auth` is required, and only if a `GH_TOKEN` isn't available.
-
 | Option        | Type       | Default                          | Description                                                   |
 | ------------- | ---------- | -------------------------------- | ------------------------------------------------------------- |
-| `--auth`      | `string`   | `process.env.GH_TOKEN`           | GitHub authentication token with _notifications_ access.      |
 | `--bandwidth` | `number`   | `6`                              | Maximum parallel requests to start at once.                   |
 | `--reason`    | `string[]` | `["subscribed"]`                 | Notification reason(s) to filter to.                          |
 | `--title`     | `string`   | `"^chore\(deps\): update .+ to"` | Notification title regular expression to filter to.           |
@@ -38,13 +37,13 @@ Only `auth` is required, and only if a `GH_TOKEN` isn't available.
 For example, providing all options on the CLI:
 
 ```shell
-npx prune-github-notifications --auth $(gh auth token) --bandwidth 10 --reason subscribed --title "^chore.+ update .+ to"
+npx prune-github-notifications --bandwidth 10 --reason subscribed --title "^chore.+ update .+ to"
 ```
 
 Running in watch mode to clear notifications every ten seconds:
 
 ```shell
-npx prune-github-notifications --auth $(gh auth token) --watch 10
+npx prune-github-notifications --watch 10
 ```
 
 ## Node.js API

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	},
 	"dependencies": {
 		"chalk": "^5.3.0",
+		"get-github-auth-token": "^0.1.0",
 		"octokit": "^3.1.2",
 		"throttled-queue": "^2.1.4",
 		"zod": "^3.22.4"
@@ -76,7 +77,6 @@
 		"vitest": "^1.3.1",
 		"yaml-eslint-parser": "^1.2.2"
 	},
-	"packageManager": "pnpm@9.0.6",
 	"engines": {
 		"node": ">=20"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      get-github-auth-token:
+        specifier: ^0.1.0
+        version: 0.1.0
       octokit:
         specifier: ^3.1.2
         version: 3.2.0
@@ -2128,6 +2131,10 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
+  get-github-auth-token@0.1.0:
+    resolution: {integrity: sha512-ENm+A39AV0X4+Ls1jiCvmqx+C8hSYTv4d5hV9Ks+EL+gx9a0P9pYYpRE1k2ExwRT3EFQabGXF1Rkdp5FIsLkiw==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
@@ -2192,6 +2199,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -2365,6 +2373,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6306,6 +6315,8 @@ snapshots:
   get-east-asian-width@1.2.0: {}
 
   get-func-name@2.0.2: {}
+
+  get-github-auth-token@0.1.0: {}
 
   get-intrinsic@1.2.4:
     dependencies:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -21,28 +21,8 @@ vi.mock("./runInWatch.js", () => ({
 }));
 
 describe("pruneGitHubNotificationsCLI", () => {
-	it("throws an error when auth is not available", async () => {
-		await expect(async () => {
-			await pruneGitHubNotificationsCLI([]);
-		}).rejects.toMatchInlineSnapshot(`
-			[ZodError: [
-			  {
-			    "code": "invalid_type",
-			    "expected": "string",
-			    "received": "undefined",
-			    "path": [
-			      "auth"
-			    ],
-			    "message": "--auth is required if a GH_TOKEN environment variable is not specified."
-			  }
-			]]
-		`);
-	});
-
 	it("passes parsed arguments to pruneGitHubNotifications when they're valid and watch mode is not enabled", async () => {
 		await pruneGitHubNotificationsCLI([
-			"--auth",
-			"abc_def",
 			"--bandwidth",
 			"123",
 			"--reason",
@@ -54,7 +34,6 @@ describe("pruneGitHubNotificationsCLI", () => {
 		]);
 
 		expect(mockPruneGitHubNotifications).toHaveBeenCalledWith({
-			auth: "abc_def",
 			bandwidth: 123,
 			filters: {
 				reason: new Set(["abc", "def"]),
@@ -66,8 +45,6 @@ describe("pruneGitHubNotificationsCLI", () => {
 
 	it("passes parsed arguments to runInWatch when they're valid and watch mode is enabled", async () => {
 		await pruneGitHubNotificationsCLI([
-			"--auth",
-			"abc_def",
 			"--bandwidth",
 			"123",
 			"--reason",
@@ -81,7 +58,6 @@ describe("pruneGitHubNotificationsCLI", () => {
 		]);
 
 		expect(mockPruneGitHubNotifications).toHaveBeenCalledWith({
-			auth: "abc_def",
 			bandwidth: 123,
 			filters: {
 				reason: new Set(["abc", "def"]),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,6 @@ import { pruneGitHubNotifications } from "./pruneGitHubNotifications.js";
 import { runInWatch } from "./runInWatch.js";
 
 const schema = z.object({
-	auth: z.string({
-		required_error:
-			"--auth is required if a GH_TOKEN environment variable is not specified.",
-	}),
 	bandwidth: z.coerce.number().optional(),
 	reason: z
 		.array(z.string())
@@ -46,11 +42,10 @@ export async function pruneGitHubNotificationsCLI(args: string[]) {
 		tokens: true,
 	});
 
-	const { auth, bandwidth, reason, title, watch } = schema.parse(values);
+	const { bandwidth, reason, title, watch } = schema.parse(values);
 
 	const action = async () =>
 		await pruneGitHubNotifications({
-			auth,
 			bandwidth,
 			filters: {
 				reason,

--- a/src/runInWatch.test.ts
+++ b/src/runInWatch.test.ts
@@ -6,7 +6,7 @@ import { runInWatch } from "./runInWatch.js";
 const mockLog = vi.fn();
 const mockSetTimeout = vi.fn();
 
-describe("pruneGitHubNotificationsCLI", () => {
+describe("runInWatch", () => {
 	beforeEach(() => {
 		console.log = mockLog;
 		globalThis.setTimeout = mockSetTimeout as unknown as typeof setTimeout;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 export interface PruneGitHubNotificationsOptions {
-	auth?: string;
 	bandwidth?: number;
 	filters?: Partial<FilterOptions>;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #167
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/prune-github-notifications/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/prune-github-notifications/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

[`get-github-auth-token`](https://github.com/JoshuaKGoldberg/get-github-auth-token) is used to retrieve a GitHub auth token from `process.env.GH_TOKEN` or executing `gh auth token`.

Removes the now-unnecessary `--auth` parameter.

💖 