### PR TITLE
feat: allow multiple title filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ npx prune-github-notifications
 
 ### CLI Options
 
-| Option        | Type       | Default                          | Description                                                   |
-| ------------- | ---------- | -------------------------------- | ------------------------------------------------------------- |
-| `--bandwidth` | `number`   | `6`                              | Maximum parallel requests to start at once.                   |
-| `--reason`    | `string[]` | `["subscribed"]`                 | Notification reason(s) to filter to.                          |
-| `--title`     | `string`   | `"^chore\(deps\): update .+ to"` | Notification title regular expression to filter to.           |
-| `--watch`     | `number`   | `0`                              | A seconds interval to continuously re-run this on, if truthy. |
+| Option        | Type       | Default                                                              | Description                                                   |
+| ------------- | ---------- | -------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `--bandwidth` | `number`   | `6`                                                                  | Maximum parallel requests to start at once.                   |
+| `--reason`    | `string[]` | `["subscribed"]`                                                     | Notification reason(s) to filter to.                          |
+| `--title`     | `string[]` | `["^chore\(deps\): update .+ to", /^build\(deps-dev\): bump .+ to"]` | Notification title regular expressions to filter to.          |
+| `--watch`     | `number`   | `0`                                                                  | A seconds interval to continuously re-run this on, if truthy. |
 
 For example, providing all options on the CLI:
 
@@ -68,12 +68,12 @@ await pruneGitHubNotifications();
 
 Only `auth` is required, and only if a `GH_TOKEN` isn't available.
 
-| Option      | Type          | Default                          | Description                                              |
-| ----------- | ------------- | -------------------------------- | -------------------------------------------------------- |
-| `auth`      | `string`      | `process.env.GH_TOKEN`           | GitHub authentication token with _notifications_ access. |
-| `bandwidth` | `number`      | `6`                              | Maximum parallel requests to start at once.              |
-| `reason`    | `Set<string>` | `Set {"subscribed"}`             | Notification reason(s) to filter to.                     |
-| `title`     | `RegExp`      | `/^chore\(deps\): update .+ to/` | Notification title regular expression to filter to.      |
+| Option      | Type          | Default                                                              | Description                                              |
+| ----------- | ------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
+| `auth`      | `string`      | `process.env.GH_TOKEN`                                               | GitHub authentication token with _notifications_ access. |
+| `bandwidth` | `number`      | `6`                                                                  | Maximum parallel requests to start at once.              |
+| `reason`    | `Set<string>` | `Set {"subscribed"}`                                                 | Notification reason(s) to filter to.                     |
+| `title`     | `RegExp[]`    | `[/^chore\(deps\): update .+ to/, /^build\(deps-dev\): bump .+ to/]` | Notification title regular expressions to filter to.     |
 
 For example, providing all options to the Node.js API:
 
@@ -82,7 +82,7 @@ await pruneGitHubNotifications({
 	auth: "gho_...",
 	bandwidth: 10,
 	reason: subscribed,
-	title: "^chore.+ update .+ to",
+	title: ["^chore.+ update .+ to"],
 });
 ```
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -37,7 +37,7 @@ describe("pruneGitHubNotificationsCLI", () => {
 			bandwidth: 123,
 			filters: {
 				reason: new Set(["abc", "def"]),
-				title: /abc.+def/,
+				title: [/abc.+def/],
 			},
 		});
 		expect(mockRunInWatch).not.toHaveBeenCalled();
@@ -61,7 +61,7 @@ describe("pruneGitHubNotificationsCLI", () => {
 			bandwidth: 123,
 			filters: {
 				reason: new Set(["abc", "def"]),
-				title: /abc.+def/,
+				title: [/abc.+def/],
 			},
 		});
 		expect(mockRunInWatch).toHaveBeenCalledWith(expect.any(Function), 10);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,8 +11,8 @@ const schema = z.object({
 		.optional()
 		.transform((value) => value && new Set(value)),
 	title: z
-		.string()
-		.transform((value) => new RegExp(value))
+		.array(z.string())
+		.transform((values) => values.map((value) => new RegExp(value)))
 		.optional(),
 	watch: z.coerce.number().optional(),
 });
@@ -33,6 +33,7 @@ export async function pruneGitHubNotificationsCLI(args: string[]) {
 				type: "string",
 			},
 			title: {
+				multiple: true,
 				type: "string",
 			},
 			watch: {

--- a/src/createThreadFilter.test.ts
+++ b/src/createThreadFilter.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import { createThreadFilter } from "./createThreadFilter.js";
 
 describe("createThreadFilter", () => {
-	it("filters out a thread when its reason does not match", () => {
+	it("filters out a thread when its reason does not match any reason", () => {
 		const filter = createThreadFilter({
-			reason: new Set(["allowed"]),
-			title: /chore/,
+			reason: new Set(["allowed", "other"]),
+			title: [/chore/],
 		});
 		const thread = { reason: "blocked", subject: { title: "chore" } };
 
@@ -15,10 +15,10 @@ describe("createThreadFilter", () => {
 		expect(actual).toBe(false);
 	});
 
-	it("filters out a thread when its title does not match", () => {
+	it("filters out a thread when its title does not match any matcher", () => {
 		const filter = createThreadFilter({
 			reason: new Set(["allowed"]),
-			title: /chore/,
+			title: [/chore/, /other/],
 		});
 		const thread = { reason: "allowed", subject: { title: "feat" } };
 
@@ -27,10 +27,22 @@ describe("createThreadFilter", () => {
 		expect(actual).toBe(false);
 	});
 
-	it("allows a thread when its reason and title match", () => {
+	it("allows a thread when its reason and title match from one each", () => {
 		const filter = createThreadFilter({
 			reason: new Set(["allowed"]),
-			title: /chore/,
+			title: [/chore/],
+		});
+		const thread = { reason: "allowed", subject: { title: "chore" } };
+
+		const actual = filter(thread);
+
+		expect(actual).toBe(true);
+	});
+
+	it("allows a thread when its reason and title match from within multiple of each", () => {
+		const filter = createThreadFilter({
+			reason: new Set(["allowed", "other"]),
+			title: [/chore/, /other/],
 		});
 		const thread = { reason: "allowed", subject: { title: "chore" } };
 

--- a/src/createThreadFilter.ts
+++ b/src/createThreadFilter.ts
@@ -11,5 +11,6 @@ export interface FilterableThread {
 
 export function createThreadFilter({ reason, title }: FilterOptions) {
 	return (thread: FilterableThread) =>
-		reason.has(thread.reason) && title.test(thread.subject.title);
+		reason.has(thread.reason) &&
+		title.some((tester) => tester.test(thread.subject.title));
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,6 +9,6 @@ export const defaultOptions = {
 
 	filters: {
 		reason: new Set(["subscribed"]),
-		title: /^chore\(deps\): update .+ to/,
+		title: [/^chore\(deps\): update .+ to/, /^build\(deps-dev\): bump .+ to/],
 	},
 } satisfies PruneGitHubNotificationsOptions;

--- a/src/pruneGitHubNotifications.test.ts
+++ b/src/pruneGitHubNotifications.test.ts
@@ -108,7 +108,7 @@ describe("pruneGitHubNotifications", () => {
 		});
 
 		await pruneGitHubNotifications({
-			filters: { reason: new Set(["other-reason"]), title: /other title/ },
+			filters: { reason: new Set(["other-reason"]), title: [/other title/] },
 		});
 
 		expect(mockRequest.mock.calls).toMatchInlineSnapshot(`

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface PruneGitHubNotificationsOptions {
 
 export interface FilterOptions {
 	reason: ReadonlySet<string>;
-	title: RegExp;
+	title: RegExp[];
 }
 
 export interface PruneGitHubNotificationsResult {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #181
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/prune-github-notifications/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/prune-github-notifications/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches `title` on the CLI to `multiple: true` and internally to `string[]`.

In theory I could have kept it singular by using a fancier regex. But that regex was getting overly complex.

💖 